### PR TITLE
Test scripts for ESF test plan

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -181,6 +181,9 @@ PyChipError pychip_DeviceController_OpenCommissioningWindow(chip::Controller::De
 
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len);
+PyChipError pychip_DeviceController_SetRequireTermsAndConditionsAcknowledgement(bool tcRequired);
+PyChipError pychip_DeviceController_SetTermsAcknowledgements(uint16_t tcVersion, uint16_t tcUserResponse);
+PyChipError pychip_DeviceController_SetSkipCommissioningComplete(bool skipCommissioningComplete);
 
 // Pairing Delegate
 PyChipError
@@ -567,6 +570,25 @@ PyChipError pychip_DeviceController_SetDefaultNtp(const char * defaultNTP)
     ReturnErrorCodeIf(!sDefaultNTPBuf.Alloc(len), ToPyChipError(CHIP_ERROR_NO_MEMORY));
     memcpy(sDefaultNTPBuf.Get(), defaultNTP, len);
     sCommissioningParameters.SetDefaultNTP(chip::app::DataModel::MakeNullable(CharSpan(sDefaultNTPBuf.Get(), len)));
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+PyChipError pychip_DeviceController_SetRequireTermsAndConditionsAcknowledgement(bool tcRequired)
+{
+    sCommissioningParameters.SetRequireTermsAndConditionsAcknowledgement(tcRequired);
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+PyChipError pychip_DeviceController_SetTermsAcknowledgements(uint16_t tcVersion, uint16_t tcUserResponse)
+{
+    sCommissioningParameters.SetTermsAndConditionsAcknowledgement(
+        { .acceptedTermsAndConditions = tcUserResponse, .acceptedTermsAndConditionsVersion = tcVersion });
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+PyChipError pychip_DeviceController_SetSkipCommissioningComplete(bool skipCommissioningComplete)
+{
+    sCommissioningParameters.SetSkipCommissioningComplete(skipCommissioningComplete);
     return ToPyChipError(CHIP_NO_ERROR);
 }
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1974,6 +1974,15 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_CreateManualCode.restype = PyChipError
             self._dmLib.pychip_CreateManualCode.argtypes = [c_uint16, c_uint32, c_char_p, c_size_t, POINTER(c_size_t)]
 
+            self._dmLib.pychip_DeviceController_SetSkipCommissioningComplete.restype = PyChipError
+            self._dmLib.pychip_DeviceController_SetSkipCommissioningComplete.argtypes = [c_bool]
+
+            self._dmLib.pychip_DeviceController_SetRequireTermsAndConditionsAcknowledgement.restype = PyChipError
+            self._dmLib.pychip_DeviceController_SetRequireTermsAndConditionsAcknowledgement.argtypes = [c_bool]
+
+            self._dmLib.pychip_DeviceController_SetTermsAcknowledgements.restype = PyChipError
+            self._dmLib.pychip_DeviceController_SetTermsAcknowledgements.argtypes = [c_uint16, c_uint16]
+
 
 class ChipDeviceController(ChipDeviceControllerBase):
     ''' The ChipDeviceCommissioner binding, named as ChipDeviceController
@@ -2100,6 +2109,27 @@ class ChipDeviceController(ChipDeviceControllerBase):
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetDSTOffset(offset, validStarting, validUntil)
+        ).raise_on_error()
+
+    def SetTCRequired(self, tcRequired: bool):
+        ''' Set whether TC Acknowledgements should be set during commissioning'''
+        self.CheckIsActive()
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_SetRequireTermsAndConditionsAcknowledgement(tcRequired)
+        ).raise_on_error()
+
+    def SetTCAcknowledgements(self, tcAcceptedVersion: int, tcUserResponse: int):
+        ''' Set the TC acknowledgements to set during commissioning'''
+        self.CheckIsActive()
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_SetTermsAcknowledgements(tcAcceptedVersion, tcUserResponse)
+        ).raise_on_error()
+
+    def SetSkipCommissioningComplete(self, skipCommissioningComplete: bool):
+        ''' Set whether to skip the commissioning complete callback'''
+        self.CheckIsActive()
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_SetSkipCommissioningComplete(skipCommissioningComplete)
         ).raise_on_error()
 
     def SetDefaultNTP(self, defaultNTP: str):

--- a/src/controller/python/chip/commissioning/__init__.py
+++ b/src/controller/python/chip/commissioning/__init__.py
@@ -73,6 +73,12 @@ class WiFiCredentials:
 
 
 @dataclasses.dataclass
+class TermsAndConditionsParameters:
+    version: int
+    user_response: int
+
+
+@dataclasses.dataclass
 class Parameters:
     pase_param: Union[PaseOverBLEParameters, PaseOverIPParameters]
     regulatory_config: RegulatoryConfig
@@ -80,6 +86,7 @@ class Parameters:
     commissionee_info: CommissioneeInfo
     wifi_credentials: WiFiCredentials
     thread_credentials: bytes
+    tc_acknowledgements: Optional[TermsAndConditionsParameters] = None
     failsafe_expiry_length_seconds: int = 600
 
 

--- a/src/controller/python/chip/commissioning/commissioning_flow_blocks.py
+++ b/src/controller/python/chip/commissioning/commissioning_flow_blocks.py
@@ -240,6 +240,15 @@ class CommissioningFlowBlocks:
         if response.errorCode != 0:
             raise commissioning.CommissionFailure(repr(response))
 
+    async def send_terms_and_conditions_acknowledgements(self, parameter: commissioning.Parameters, node_id: int):
+        self._logger.info("Settings Terms and Conditions")
+        if parameter.tc_acknowledgements:
+            response = await self._devCtrl.SendCommand(node_id, commissioning.ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Commands.SetTCAcknowledgements(
+                TCVersion=parameter.tc_acknowledgements.version, TCUserResponse=parameter.tc_acknowledgements.user_response
+            ))
+        if response.errorCode != 0:
+            raise commissioning.CommissionFailure(repr(response))
+
     async def complete_commission(self, node_id: int):
         response = await self._devCtrl.SendCommand(node_id, commissioning.ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Commands.CommissioningComplete())
         if response.errorCode != 0:

--- a/src/python_testing/TC_CGEN_2_5.py
+++ b/src/python_testing/TC_CGEN_2_5.py
@@ -1,0 +1,147 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${TERMS_AND_CONDITIONS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --KVS kvs1
+# test-runner-run/run1/script-args: --in-test-commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --trace-to json:log
+# === END CI TEST ARGUMENTS ===
+
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.commissioning import ROOT_ENDPOINT_ID
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_CGEN_2_5(MatterBaseTest):
+    def desc_TC_CGEN_2_5(self) -> str:
+        return "[TC-CGEN-2.5] Verification For SetTCAcknowledgements [DUT as Server]"
+
+    def steps_TC_CGEN_2_5(self) -> list[TestStep]:
+        return [
+            TestStep(1, "TH starts commissioning the DUT. It performs all commissioning steps from ArmFailSafe, except SetTCAcknowledgements and CommissioningComplete.", is_commissioning=False),
+            TestStep(2, "TH reads TCAcknowledgementsRequired attribute from the DUT."),
+            TestStep(3, "TH sends SetTCAcknowledgements to DUT with the following values:\nTCVersion: Greater than or equal to TCMinRequiredVersion on DUT\nTCUserResponse: All terms required by DUT accepted"),
+            TestStep(4, "TH sends CommissioningComplete to DUT."),
+            TestStep(5, "TH reads TCAcceptedVersion attribute from the DUT."),
+            TestStep(6, "TH reads TCAcknowledgements attribute from the DUT."),
+            TestStep(7, "TH reads TCMinRequiredVersion attribute from the DUT."),
+            TestStep(8, "TH reads TCAcknowledgementsRequired attribute from the DUT."),
+            TestStep(9, "TH sends the SetTCAcknowledgements command to the DUT with the fields set as follows:\nTCVersion: 0\nTCUserResponse: 0"),
+        ]
+
+    @async_test_body
+    async def test_TC_CGEN_2_5(self):
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+
+        # Don't set TCs for the next commissioning and skip CommissioningComplete so we can manually call CommissioningComplete in order to check the response error code
+        self.step(1)
+        commissioner.SetTCRequired(False)
+        commissioner.SetSkipCommissioningComplete(True)
+        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+        await self.commission_devices()
+
+        self.step(2)
+        response: dict[int, Clusters.GeneralCommissioning] = await commissioner.ReadAttribute(
+            nodeid=self.dut_node_id,
+            attributes=[
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcceptedVersion),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCMinRequiredVersion),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcknowledgements),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcknowledgementsRequired),
+            ])
+        tcAcceptedVersion = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcceptedVersion]
+        tcMinRequiredVersion = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCMinRequiredVersion]
+        tcAcknowledgements = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcknowledgements]
+        tcAcknowledgementsRequired = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcknowledgementsRequired]
+
+        # Verify that TCAcknowledgementsRequired value is representable in the 'Bool' type
+        # Verify that TCAcknowledgementsRequired value is True
+        asserts.assert_equal(tcAcknowledgementsRequired, True, 'Incorrect TCAcknowledgementsRequired')
+
+        self.step(3)
+        response: Clusters.GeneralCommissioning.Commands.SetTCAcknowledgementsResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.SetTCAcknowledgements(TCVersion=2**16 - 1, TCUserResponse=2**16 - 1),
+            timedRequestTimeoutMs=1000)
+        # Verify that DUT sends SetTCAcknowledgementsResponse Command to TH With ErrorCode as 'OK'(0).
+        asserts.assert_equal(response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
+                             'Incorrect error code')
+
+        self.step(4)
+        response: Clusters.GeneralCommissioning.Commands.CommissioningCompleteResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.CommissioningComplete(),
+            timedRequestTimeoutMs=1000)
+        # Verify that DUT sends CommissioningCompleteResponse Command to TH With ErrorCode as 'OK'(0).
+        asserts.assert_equal(response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
+                             'Incorrect error code')
+
+        # Read attributes of interest
+        response: dict[int, Clusters.GeneralCommissioning] = await commissioner.ReadAttribute(
+            nodeid=self.dut_node_id,
+            attributes=[
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcceptedVersion),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCMinRequiredVersion),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcknowledgements),
+                (ROOT_ENDPOINT_ID, Clusters.GeneralCommissioning.Attributes.TCAcknowledgementsRequired),
+            ])
+        tcAcceptedVersion = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcceptedVersion]
+        tcMinRequiredVersion = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCMinRequiredVersion]
+        tcAcknowledgements = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcknowledgements]
+        tcAcknowledgementsRequired = response[ROOT_ENDPOINT_ID][Clusters.GeneralCommissioning][Clusters.GeneralCommissioning.Attributes.TCAcknowledgementsRequired]
+
+        self.step(5)
+        # Verify that TCAcceptedVersion value fits in the 'uint16' type
+        asserts.assert_less(tcAcceptedVersion, 2**16, 'Incorrect TCAcceptedVersion')
+        # Verify that TCAcceptedVersion is the value sent in step 3
+        asserts.assert_equal(tcAcceptedVersion, 2**16 - 1, 'Incorrect TCAcceptedVersion')
+
+        self.step(6)
+        # Verify that TCAcknowledgements is a value representable in the map16 type
+        # Verify that TCAcknowledgements is the value sent in step 3
+        asserts.assert_equal(tcAcknowledgements, 2**16 - 1, 'Incorrect TCAcknowledgements')
+
+        self.step(7)
+        # Verify that TCMinRequiredVersion value fits in the 'uint16' type
+        asserts.assert_less(tcMinRequiredVersion, 2**16, 'Incorrect TCMinRequiredVersion')
+
+        self.step(8)
+        # Verify that TCAcknowledgementsRequired value is False
+        asserts.assert_equal(tcAcknowledgementsRequired, False, 'Incorrect TCAcknowledgementsRequired')
+
+        self.step(9)
+        response: Clusters.GeneralCommissioning.Commands.SetTCAcknowledgementsResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.SetTCAcknowledgements(TCVersion=0, TCUserResponse=0),
+            timedRequestTimeoutMs=1000)
+        # Verify that DUT sends SetTCAcknowledgementsResponse Command to TH With ErrorCode as 'TCMinVersionNotMet'(7)
+        asserts.assert_equal(response.errorCode,
+                             Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kTCMinVersionNotMet, 'Incorrect error code')
+        # Verify that TCAcceptedVersion and TCAcknowledgements still contain the values sent in step 3.
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CGEN_2_6.py
+++ b/src/python_testing/TC_CGEN_2_6.py
@@ -1,0 +1,66 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${TERMS_AND_CONDITIONS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --KVS kvs1
+# test-runner-run/run1/script-args: --in-test-commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --trace-to json:log
+# === END CI TEST ARGUMENTS ===
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.commissioning import ROOT_ENDPOINT_ID
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_CGEN_2_6(MatterBaseTest):
+    def desc_TC_CGEN_2_6(self) -> str:
+        return "[TC-CGEN-2.6] Verification For CommissioningComplete no terms accepted when required [DUT as Server]"
+
+    def steps_TC_CGEN_2_6(self) -> list[TestStep]:
+        return [
+            TestStep(1,  "TH starts commissioning the DUT. It performs all commissioning steps from ArmFailSafe to CommissioningComplete, except for TC configuration with SetTCAcknowledgements.", is_commissioning=False),
+        ]
+
+    @async_test_body
+    async def test_TC_CGEN_2_6(self):
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+
+        # Don't set TCs for the next commissioning and skip CommissioningComplete so we can manually call CommissioningComplete in order to check the response error code
+        commissioner.SetTCRequired(False)
+        commissioner.SetSkipCommissioningComplete(True)
+        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+
+        self.step(1)
+        await self.commission_devices()
+        response: Clusters.GeneralCommissioning.Commands.CommissioningCompleteResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.CommissioningComplete(),
+            timedRequestTimeoutMs=1000)
+
+        # Verify that DUT sends CommissioningCompleteResponse Command to TH With ErrorCode as 'TCAcknowledgementsNotReceived'(6).
+        asserts.assert_equal(
+            response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kTCAcknowledgementsNotReceived, 'Incorrect error code')
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CGEN_2_7.py
+++ b/src/python_testing/TC_CGEN_2_7.py
@@ -1,0 +1,81 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${TERMS_AND_CONDITIONS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --KVS kvs1
+# test-runner-run/run1/script-args: --in-test-commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --trace-to json:log
+# === END CI TEST ARGUMENTS ===
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.commissioning import ROOT_ENDPOINT_ID
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_CGEN_2_7(MatterBaseTest):
+    def desc_TC_CGEN_2_7(self) -> str:
+        return "[TC-CGEN-2.7] Verification For CommissioningComplete when SetTCAcknowledgements provides invalid terms [DUT as Server]"
+
+    def steps_TC_CGEN_2_7(self) -> list[TestStep]:
+        return [
+            TestStep(1,  "TH starts commissioning the DUT. It performs all commissioning steps from ArmFailSafe, except SetTCAcknowledgements and CommissioningComplete.", is_commissioning=False),
+            TestStep(2,  "TH sends SetTCAcknowledgements to DUT with the following values:\nTCVersion: Greater than or equal to TCMinRequiredVersion on DUT\nTCUserResponse: 0"),
+            TestStep(3,  "TH sends CommissioningComplete to DUT."),
+        ]
+
+    @async_test_body
+    async def test_TC_CGEN_2_7(self):
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+
+        # Don't set TCs for the next commissioning and skip CommissioningComplete so we can manually call CommissioningComplete in order to check the response error code
+        commissioner.SetTCRequired(False)
+        commissioner.SetSkipCommissioningComplete(True)
+        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+
+        self.step(1)
+        await self.commission_devices()
+
+        self.step(2)
+        response: Clusters.GeneralCommissioning.Commands.SetTCAcknowledgementsResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.SetTCAcknowledgements(TCVersion=2**16 - 1, TCUserResponse=0),
+            timedRequestTimeoutMs=1000)
+
+        # Verify that DUT sends SetTCAcknowledgementsResponse Command to TH With ErrorCode as 'RequiredTCNotAccepted'(5).
+        asserts.assert_equal(
+            response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kRequiredTCNotAccepted, 'Incorrect error code')
+
+        self.step(3)
+        response: Clusters.GeneralCommissioning.Commands.CommissioningCompleteResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.CommissioningComplete(),
+            timedRequestTimeoutMs=1000)
+
+        # Verify that DUT sends CommissioningCompleteResponse Command to TH With ErrorCode as 'TCAcknowledgementsNotReceived'(6).
+        asserts.assert_equal(
+            response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kTCAcknowledgementsNotReceived, 'Incorrect error code')
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -1,0 +1,98 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${TERMS_AND_CONDITIONS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --KVS kvs1
+# test-runner-run/run1/script-args: --in-test-commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --trace-to json:log
+# === END CI TEST ARGUMENTS ===
+
+from typing import List
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.commissioning import ROOT_ENDPOINT_ID
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_CGEN_2_8(MatterBaseTest):
+
+    async def remove_commissioner_fabric(self):
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+
+        fabrics: List[Clusters.OperationalCredentials.Structs.FabricDescriptorStruct] = await self.read_single_attribute(
+            dev_ctrl=commissioner,
+            node_id=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            attribute=Clusters.OperationalCredentials.Attributes.Fabrics)
+
+        # Re-order the list of fabrics so that the test harness admin fabric is removed last
+        commissioner_fabric = next((fabric for fabric in fabrics if fabric.fabricIndex == commissioner.fabricId), None)
+        fabrics.remove(commissioner_fabric)
+        fabrics.append(commissioner_fabric)
+
+        for fabric in fabrics:
+            response: Clusters.OperationalCredentials.Commands.NOCResponse = await commissioner.SendCommand(
+                nodeid=self.dut_node_id,
+                endpoint=ROOT_ENDPOINT_ID,
+                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(fabric.fabricIndex),
+                timedRequestTimeoutMs=1000)
+            asserts.assert_equal(response.statusCode, Clusters.OperationalCredentials.Enums.NodeOperationalCertStatusEnum.kOk)
+
+    def desc_TC_CGEN_2_8(self) -> str:
+        return "[TC-CGEN-2.8] Verification For Terms and Conditions Reset [DUT as Server]"
+
+    def steps_TC_CGEN_2_8(self) -> list[TestStep]:
+        return [
+            TestStep(1, "DUT requires terms and conditions. DUT has been successfully commissioned."),
+            TestStep(2, "User performs factory reset."),
+            TestStep(3, "User triggers USER INTENT to set the device to be in commissioning mode."),
+            TestStep(4, "TH starts commissioning the DUT. It performs all commissioning steps, except for TC configuration with SetTCAcknowledgements."),
+        ]
+
+    @async_test_body
+    async def test_TC_CGEN_2_8(self):
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+
+        self.step(1)
+        self.step(2)
+        self.step(3)
+        self.wait_for_user_input(prompt_msg="Set the DUT into commissioning mode")
+
+        # Don't set TCs for the next commissioning and skip CommissioningComplete so we can manually call CommissioningComplete in order to check the response error code
+        commissioner.SetTCRequired(False)
+        commissioner.SetSkipCommissioningComplete(True)
+        self.matter_test_config.commissioning_method = self.matter_test_config.in_test_commissioning_method
+        await self.commission_devices()
+
+        self.step(4)
+        response: Clusters.GeneralCommissioning.Commands.CommissioningCompleteResponse = await commissioner.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            payload=Clusters.GeneralCommissioning.Commands.CommissioningComplete(),
+            timedRequestTimeoutMs=1000)
+        # Verify that DUT sends CommissioningCompleteResponse Command to TH With ErrorCode as 'TCAcknowledgementsNotReceived'(6).
+        asserts.assert_equal(
+            response.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kTCAcknowledgementsNotReceived, 'Incorrect error code')
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -630,6 +630,7 @@ class MatterTestConfig:
     app_pid: int = 0
 
     commissioning_method: Optional[str] = None
+    in_test_commissioning_method: Optional[str] = None
     discriminators: List[int] = field(default_factory=list)
     setup_passcodes: List[int] = field(default_factory=list)
     commissionee_ip_address_just_for_testing: Optional[str] = None
@@ -666,6 +667,10 @@ class MatterTestConfig:
     chip_tool_credentials_path: Optional[pathlib.Path] = None
 
     trace_to: List[str] = field(default_factory=list)
+
+    # Accepted Terms and Conditions if used
+    tc_version: int = None
+    tc_user_response: int = None
 
 
 class ClusterMapper:
@@ -938,6 +943,18 @@ class MatterBaseTest(base_test.BaseTestClass):
         self.is_commissioning = False
         # The named pipe name must be set in the derived classes
         self.app_pipe = None
+
+    async def commission_devices(self) -> bool:
+        conf = self.matter_test_config
+
+        for commission_idx, node_id in enumerate(conf.dut_node_ids):
+            logging.info("Starting commissioning for root index %d, fabric ID 0x%016X, node ID 0x%016X" %
+                         (conf.root_of_trust_index, conf.fabric_id, node_id))
+            logging.info("Commissioning method: %s" % conf.commissioning_method)
+
+            await CommissionDeviceTest.commission_device(self, commission_idx)
+
+        return True
 
     def get_test_steps(self, test: str) -> list[TestStep]:
         ''' Retrieves the test step list for the given test
@@ -1734,6 +1751,7 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
     config.dut_node_ids = args.dut_node_ids
 
     config.commissioning_method = args.commissioning_method
+    config.in_test_commissioning_method = args.in_test_commissioning_method
     config.commission_only = args.commission_only
 
     config.qr_code_content.extend(args.qr_code)
@@ -1836,6 +1854,9 @@ def convert_args_to_matter_config(args: argparse.Namespace) -> MatterTestConfig:
     config.controller_node_id = args.controller_node_id
     config.trace_to = args.trace_to
 
+    config.tc_version = args.tc_version
+    config.tc_user_response = args.tc_user_response
+
     # Accumulate all command-line-passed named args
     all_global_args = []
     argsets = [item for item in (args.int_arg, args.float_arg, args.string_arg, args.json_arg,
@@ -1894,6 +1915,10 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
                                   metavar='METHOD_NAME',
                                   choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
                                   help='Name of commissioning method to use')
+    commission_group.add_argument('--in-test-commissioning-method', type=str,
+                                  metavar='METHOD_NAME',
+                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
+                                  help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',
                                   dest='discriminators',
@@ -1928,6 +1953,10 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
 
     commission_group.add_argument('--commission-only', action="store_true", default=False,
                                   help="If true, test exits after commissioning without running subsequent tests")
+
+    commission_group.add_argument('--tc-version', type=int, help="Terms and conditions version")
+
+    commission_group.add_argument('--tc-user-response', type=int, help="Terms and conditions acknowledgements")
 
     code_group = parser.add_mutually_exclusive_group(required=False)
 
@@ -2200,20 +2229,21 @@ class CommissionDeviceTest(MatterBaseTest):
         self.is_commissioning = True
 
     def test_run_commissioning(self):
-        conf = self.matter_test_config
-        for commission_idx, node_id in enumerate(conf.dut_node_ids):
-            logging.info("Starting commissioning for root index %d, fabric ID 0x%016X, node ID 0x%016X" %
-                         (conf.root_of_trust_index, conf.fabric_id, node_id))
-            logging.info("Commissioning method: %s" % conf.commissioning_method)
+        if not asyncio.run(self.commission_devices()):
+            raise signals.TestAbortAll("Failed to commission node")
 
-            if not asyncio.run(self._commission_device(commission_idx)):
-                raise signals.TestAbortAll("Failed to commission node")
+    async def commission_device(instance: MatterBaseTest, i) -> bool:
+        dev_ctrl = instance.default_controller
+        conf = instance.matter_test_config
 
-    async def _commission_device(self, i) -> bool:
-        dev_ctrl = self.default_controller
-        conf = self.matter_test_config
+        info = instance.get_setup_payload_info()[i]
 
-        info = self.get_setup_payload_info()[i]
+        if conf.tc_version is not None and conf.tc_user_response is not None:
+            logging.debug(f"Setting TC Acknowledgements to version {conf.tc_version} with user response {conf.tc_user_response}.")
+            dev_ctrl.SetTCAcknowledgements(conf.tc_version, conf.tc_user_response)
+            dev_ctrl.SetTCRequired(True)
+        else:
+            dev_ctrl.SetTCRequired(False)
 
         if conf.commissioning_method == "on-network":
             try:


### PR DESCRIPTION
- Preliminary PR to show test scripts and changes to accommodate them.
- Updates may be needed to reflect changes to test plan during PR
- TC arguments allow for TC acceptance to be used outside of ESF tests, preventing other tests from needing changes if the device uses ESF